### PR TITLE
Add unzip to builds

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update && apt-get install -y \
 	libxml2-dev \
 	ssmtp \
 	imagemagick \
-	libmagickwand-dev
+	libmagickwand-dev \
+	unzip
 
 RUN pecl install imagick
 RUN docker-php-ext-enable imagick

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update && apt-get install -y \
 	libxml2-dev \
 	ssmtp \
 	imagemagick \
-	libmagickwand-dev
+	libmagickwand-dev \
+	unzip
 
 RUN pecl install imagick
 RUN docker-php-ext-enable imagick

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update && apt-get install -y \
 	libxml2-dev \
 	ssmtp \
 	imagemagick \
-	libmagickwand-dev
+	libmagickwand-dev \
+	unzip
 
 RUN pecl install imagick
 RUN docker-php-ext-enable imagick


### PR DESCRIPTION
WP-CLI's popular [`wp scaffold plugin-tests` command](https://developer.wordpress.org/cli/commands/scaffold/plugin-tests/) has an installer script that makes use of the `unzip` package:

https://github.com/wp-cli/scaffold-command/blob/v1.1.1/templates/install-wp-tests.sh#L64

It'd be nice if these images included it so that it doesn't need to be manually installed.
  