### PR TITLE
Add PHP 7.2 tag

### DIFF
--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -1,0 +1,29 @@
+FROM johnpbloch/phpfpm:7.2
+
+RUN curl -L https://phar.phpunit.de/phpunit.phar > /tmp/phpunit.phar \
+	&& chmod +x /tmp/phpunit.phar \
+	&& mv /tmp/phpunit.phar /usr/local/bin/phpunit
+
+RUN apt-get update && apt-get install -y \
+	git \
+	subversion \
+	wget \
+	libxml2-dev \
+	ssmtp \
+	imagemagick \
+	libmagickwand-dev \
+	unzip
+
+RUN pecl install imagick
+RUN docker-php-ext-enable imagick
+
+RUN docker-php-ext-install soap
+RUN echo "mailhub=mailcatcher:1025\nUseTLS=NO\nFromLineOverride=YES" > /etc/ssmtp/ssmtp.conf
+
+RUN apt-get remove -y libmagickwand-dev libxml2-dev && \
+	apt-get autoremove -y && \
+	apt-get clean
+
+CMD ["php-fpm"]
+
+EXPOSE 9000


### PR DESCRIPTION
Adds [PHP 7.2](http://php.net/releases/7_2_0.php) tag.  Looks to be available in the [upstream image](https://hub.docker.com/r/johnpbloch/phpfpm/tags/).